### PR TITLE
fix: use of prettier-ignore

### DIFF
--- a/src/core/declaration.ts
+++ b/src/core/declaration.ts
@@ -141,7 +141,7 @@ ${head}`
     ${declarations.directive.join('\n    ')}
   }`
   }
-  code += '\n}\n'
+  code += '\n}\n/* prettier-ignore */\n'
   return code
 }
 

--- a/test/__snapshots__/dts.test.ts.snap
+++ b/test/__snapshots__/dts.test.ts.snap
@@ -15,6 +15,7 @@ declare module 'vue' {
     TestComp: typeof import('test/component/TestComp')['default']
   }
 }
+/* prettier-ignore */
 "
 `;
 
@@ -32,6 +33,7 @@ declare module 'vue' {
   }
 }
 "
+/* prettier-ignore */
 `;
 
 exports[`dts > getDeclaration 1`] = `
@@ -53,6 +55,7 @@ declare module 'vue' {
   }
 }
 "
+/* prettier-ignore */
 `;
 
 exports[`dts > parseDeclaration - has icon component like <IMdi:diceD12> 1`] = `
@@ -108,6 +111,7 @@ declare module 'vue' {
   }
 }
 "
+/* prettier-ignore */
 `;
 
 exports[`dts > writeDeclaration - keep unused 1`] = `
@@ -132,6 +136,7 @@ declare module 'vue' {
   }
 }
 "
+/* prettier-ignore */
 `;
 
 exports[`dts > writeDeclaration 1`] = `
@@ -153,4 +158,5 @@ declare module 'vue' {
   }
 }
 "
+/* prettier-ignore */
 `;

--- a/test/dts.test.ts
+++ b/test/dts.test.ts
@@ -136,7 +136,8 @@ declare module 'vue' {
     ComponentB: typeof import('./src/components/ComponentB.vue')['default']
     ComponentC: typeof import('./src/components/component-c.vue')['default']
   }
-}`
+}
+/* prettier-ignore */`
 
     const imports = parseDeclaration(code)
     expect(imports).matchSnapshot()
@@ -157,7 +158,8 @@ declare module 'vue' {
     'IMdi:diceD12': typeof import('~icons/mdi/dice-d12')['default']
     IMdiLightAlarm: typeof import('~icons/mdi-light/alarm')['default']
   }
-}`
+}
+/* prettier-ignore */`
 
     const imports = parseDeclaration(code)
     expect(imports).matchSnapshot()
@@ -184,7 +186,8 @@ declare module 'vue' {
     vLoading: typeof import('test/directive/Loading')['default']
     vSome: typeof import('test/directive/Some')['default']
   }
-}`
+}
+/* prettier-ignore */`
 
     const imports = parseDeclaration(code)
     expect(imports).matchSnapshot()


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
When I used prettier to format the code, I found that the `components.d.ts` file automatically generated by `unplugin-vue-components` was formatted, but the top of the file was written to prohibit eslint and prettier .
After testing, I found that `/* eslint-disable */` is effective, but `/* prettier-ignore */` does not.

BUG reproduction:
Before prettier formatting:
<img width="434" alt="Snipaste_2023-09-05_21-55-06" src="https://github.com/unplugin/unplugin-vue-components/assets/50048802/c87b965b-be49-4bc7-8b03-35e60964b5c8">

After prettier formatting:
<img width="502" alt="Snipaste_2023-09-05_21-55-19" src="https://github.com/unplugin/unplugin-vue-components/assets/50048802/f374c65c-859a-42d2-b38e-e8c296a094a8">
You can see that single quotes have changed to double quotes, proving that`/* prettier-ignore */`has no effect

Then I checked the git history and found the changes proposed by this PR: https://github.com/unplugin/unplugin-vue-components/pull/597
The original intention of this change is to prevent `eslint` and `prettier` from formatting the entire file, not just the `export {}` line.
So I added the last line `/* prettier-ignore */` in the relevant code, this will ensure that the whole file will not be formatted and will not affect the functionality of other comments
### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
