### PR TITLE
User's exclude config maybe cause Vite's pre-bundled file's sourcemap missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,8 @@ Components({
   // Allow for components to override other components with the same name
   allowOverrides: false,
 
-  // filters for transforming targets
+  // Filters for transforming targets
+  // Your filters config will merge into default config
   include: [/\.vue$/, /\.vue\?vue/],
   exclude: [/[\\/]node_modules[\\/]/, /[\\/]\.git[\\/]/, /[\\/]\.nuxt[\\/]/],
 

--- a/src/core/unplugin.ts
+++ b/src/core/unplugin.ts
@@ -12,9 +12,12 @@ import { shouldTransform, stringifyComponentImport } from './utils'
 const PLUGIN_NAME = 'unplugin:webpack'
 
 export default createUnplugin<Options>((options = {}) => {
+  const include = Array.isArray(options.include) ? options.include : [options.include]
+  const exclude = Array.isArray(options.exclude) ? options.exclude : [options.exclude]
+
   const filter = createFilter(
-    options.include || [/\.vue$/, /\.vue\?vue/, /\.vue\?v=/],
-    options.exclude || [/[\\/]node_modules[\\/]/, /[\\/]\.git[\\/]/, /[\\/]\.nuxt[\\/]/],
+    [/\.vue$/, /\.vue\?vue/, /\.vue\?v=/, ...include],
+    [/[\\/]node_modules[\\/]/, /[\\/]\.git[\\/]/, /[\\/]\.nuxt[\\/]/, ...exclude],
   )
   const ctx: Context = new Context(options)
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

When user set their `exclude` option to an Array like `[/aaa/,/bbb/]`

User's `exclude` DO NOT contains `node_modules/.vite` or `node_modules` which is specified in default `exclude` array.

Then when Browser request pre-bundled file, plugin WILL transform them and generate a new sourcemap for them

The new sourcemap  will override the original sourcemap generated by `vite`

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
