### PR TITLE
fix(utils): collapse prefixes in PascalCase name

### DIFF
--- a/examples/vite-vue3/src/components/kebab-case/KebabCaseFile.vue
+++ b/examples/vite-vue3/src/components/kebab-case/KebabCaseFile.vue
@@ -1,0 +1,9 @@
+<script>
+export default {
+  name: 'KebabCaseFile',
+}
+</script>
+
+<template>
+  <h3>KebabCaseFile Component: <code>kebab-case/KebabCaseFile.vue</code></h3>
+</template>

--- a/examples/vite-vue3/src/components/kebab-case/kebab-case-collapse/KebabCaseCollapseFile.vue
+++ b/examples/vite-vue3/src/components/kebab-case/kebab-case-collapse/KebabCaseCollapseFile.vue
@@ -1,0 +1,9 @@
+<script>
+export default {
+  name: 'KebabCaseCollapseFile',
+}
+</script>
+
+<template>
+  <h3>KebabCaseCollapseFile Component: <code>kebab-case/kebab-case-collapse/KebabCaseCollapseFile.vue</code></h3>
+</template>

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -162,11 +162,10 @@ export function getNameFromFilePath(filePath: string, options: ResolvedOptions):
           const pascalCasedName = pascalCase(fileOrFolderName)
 
           for (const parentFolder of [...collapsed].reverse()) {
-            cumulativePrefix = `${capitalize(parentFolder)}${cumulativePrefix}`
+            cumulativePrefix = `${parentFolder}${cumulativePrefix}`
 
-            const pascalCasedPrefix = pascalCase(cumulativePrefix)
-            if (pascalCasedName.startsWith(pascalCasedPrefix)) {
-              const collapseSamePrefix = pascalCasedName.slice(pascalCasedPrefix.length)
+            if (pascalCasedName.startsWith(cumulativePrefix)) {
+              const collapseSamePrefix = pascalCasedName.slice(cumulativePrefix.length)
 
               collapsed.push(collapseSamePrefix)
 

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -163,8 +163,9 @@ export function getNameFromFilePath(filePath: string, options: ResolvedOptions):
           for (const parentFolder of [...collapsed].reverse()) {
             cumulativePrefix = `${capitalize(parentFolder)}${cumulativePrefix}`
 
-            if (pascalCase(fileOrFolderName).startsWith(pascalCase(cumulativePrefix))) {
-              const collapseSamePrefix = fileOrFolderName.slice(cumulativePrefix.length)
+            const pascalCasedPrefix = pascalCase(cumulativePrefix)
+            if (pascalCase(fileOrFolderName).startsWith(pascalCasedPrefix)) {
+              const collapseSamePrefix = fileOrFolderName.slice(pascalCasedPrefix.length)
 
               collapsed.push(collapseSamePrefix)
 

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -159,13 +159,14 @@ export function getNameFromFilePath(filePath: string, options: ResolvedOptions):
         for (const fileOrFolderName of namespaced) {
           let cumulativePrefix = ''
           let didCollapse = false
+          const pascalCasedName = pascalCase(fileOrFolderName)
 
           for (const parentFolder of [...collapsed].reverse()) {
             cumulativePrefix = `${capitalize(parentFolder)}${cumulativePrefix}`
 
             const pascalCasedPrefix = pascalCase(cumulativePrefix)
-            if (pascalCase(fileOrFolderName).startsWith(pascalCasedPrefix)) {
-              const collapseSamePrefix = fileOrFolderName.slice(pascalCasedPrefix.length)
+            if (pascalCasedName.startsWith(pascalCasedPrefix)) {
+              const collapseSamePrefix = pascalCasedName.slice(pascalCasedPrefix.length)
 
               collapsed.push(collapseSamePrefix)
 
@@ -175,7 +176,7 @@ export function getNameFromFilePath(filePath: string, options: ResolvedOptions):
           }
 
           if (!didCollapse)
-            collapsed.push(fileOrFolderName)
+            collapsed.push(pascalCasedName)
         }
 
         namespaced = collapsed

--- a/test/__snapshots__/search.test.ts.snap
+++ b/test/__snapshots__/search.test.ts.snap
@@ -39,6 +39,14 @@ exports[`search > should with namespace & collapse 1`] = `
     "from": "src/components/ComponentD.vue",
   },
   {
+    "as": "KebabCaseCollapseFile",
+    "from": "src/components/kebab-case/kebab-case-collapse/KebabCaseCollapseFile.vue",
+  },
+  {
+    "as": "KebabCaseFile",
+    "from": "src/components/kebab-case/KebabCaseFile.vue",
+  },
+  {
     "as": "Recursive",
     "from": "src/components/Recursive.vue",
   },
@@ -90,6 +98,14 @@ exports[`search > should with namespace 1`] = `
   {
     "as": "ComponentD",
     "from": "src/components/ComponentD.vue",
+  },
+  {
+    "as": "KebabCaseKebabCaseCollapseKebabCaseCollapseFile",
+    "from": "src/components/kebab-case/kebab-case-collapse/KebabCaseCollapseFile.vue",
+  },
+  {
+    "as": "KebabCaseKebabCaseFile",
+    "from": "src/components/kebab-case/KebabCaseFile.vue",
   },
   {
     "as": "Recursive",
@@ -151,6 +167,14 @@ exports[`search > should work 1`] = `
   {
     "as": "FolderAndComponentPartially",
     "from": "src/components/collapse/collapseFolder/FolderAndComponentPartially.vue",
+  },
+  {
+    "as": "KebabCaseCollapseFile",
+    "from": "src/components/kebab-case/kebab-case-collapse/KebabCaseCollapseFile.vue",
+  },
+  {
+    "as": "KebabCaseFile",
+    "from": "src/components/kebab-case/KebabCaseFile.vue",
   },
   {
     "as": "Recursive",


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
`collapseSamePrefixes` should directly count the PascalCased name's length instead of kebab-cased one.

### Linked Issues
fixes #738 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
