### PR TITLE
fix: Update devui.ts，部分组件按需引入不生效bug修复

### DIFF
--- a/src/core/resolvers/devui.ts
+++ b/src/core/resolvers/devui.ts
@@ -74,17 +74,23 @@ function getSideEffects(name: string, filename: string) {
   if (['splitter-pane'].includes(name))
     return resolveDirectory('splitter', filename)
 
-  if (["option"].includes(name))
+  if (['option', 'option-group'].includes(name))
     return resolveDirectory("select", filename);
 
-  if (["modal-header"].includes(name))
+  if (['modal-header', 'modal-footer'].includes(name))
     return resolveDirectory("modal", filename);
 
-  if (["breadcrumb-item"].includes(name))
+  if (['breadcrumb-item'].includes(name))
     return resolveDirectory("breadcrumb", filename);
 
-  if (["skeleton-item"].includes(name))
+  if (['skeleton-item'].includes(name))
     return resolveDirectory("skeleton", filename);
+
+  if (['button-group'].includes(name))
+    return resolveDirectory("button", filename);
+
+  if (['checkbox-group'].includes(name))
+    return resolveDirectory("checkbox", filename);
 
   return resolveDirectory(name, filename)
 }

--- a/src/core/resolvers/devui.ts
+++ b/src/core/resolvers/devui.ts
@@ -53,7 +53,7 @@ function getSideEffects(name: string, filename: string) {
   if (['tabs', 'tab'].includes(name))
     return resolveDirectory('tabs', filename)
 
-  if (['form', 'form-item'].includes(name))
+  if (['form', 'form-item', 'form-operation'].includes(name))
     return resolveDirectory('form', filename)
 
   if (['collapse', 'collapse-item'].includes(name))
@@ -73,6 +73,18 @@ function getSideEffects(name: string, filename: string) {
 
   if (['splitter-pane'].includes(name))
     return resolveDirectory('splitter', filename)
+
+  if (["option"].includes(name))
+    return resolveDirectory("select", filename);
+
+  if (["modal-header"].includes(name))
+    return resolveDirectory("modal", filename);
+
+  if (["breadcrumb-item"].includes(name))
+    return resolveDirectory("breadcrumb", filename);
+
+  if (["skeleton-item"].includes(name))
+    return resolveDirectory("skeleton", filename);
 
   return resolveDirectory(name, filename)
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
option， skeleton-item，modal-header，form-operation，breadcrumb-item等
这部分组件无法做到按需引入
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
https://github.com/DevCloudFE/vue-devui/issues/1781

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
