### PR TITLE
fix: use import for QuasarResolver api-list.json

### DIFF
--- a/src/core/resolvers/quasar.ts
+++ b/src/core/resolvers/quasar.ts
@@ -1,5 +1,3 @@
-import { promises as fs } from 'node:fs'
-import { resolveModule } from 'local-pkg'
 import type { ComponentResolver } from '../../types'
 
 /**
@@ -14,9 +12,12 @@ export function QuasarResolver(): ComponentResolver {
     type: 'component',
     resolve: async (name: string) => {
       if (!components.length) {
-        const quasarApiListPath = resolveModule('quasar/dist/transforms/api-list.json')
-        if (quasarApiListPath)
-          components = JSON.parse(await fs.readFile(quasarApiListPath, 'utf-8'))
+        ({
+          default: components,
+        } // @ts-expect-error no quasar types
+          = await import('quasar/dist/transforms/api-list.json', {
+            assert: { type: 'json' },
+          }))
       }
 
       if (components.includes(name))

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,6 +5,7 @@ export const tsup: Options = {
     'src/*.ts',
   ],
   format: ['cjs', 'esm'],
+  external: ['quasar'],
   dts: true,
   splitting: true,
   clean: true,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
After upgrading my packages, the QuasarResolver stopped working. I think this is due to Quasar 2.16.0 having moved to ESM (https://github.com/quasarframework/quasar/releases/tag/quasar-v2.16.0). `resolveModule` fails for some reason which leads to an empty list. The strange thing is that adding a `console.log()` in the resolve function seems to fix it...

Instead of using `readFile` it now uses `import()`
### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
