### PR TITLE
fix: get wrong vue version in monorepo

### DIFF
--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -84,7 +84,9 @@ export function resolveOptions(options: Options, root: string): ResolvedOptions 
 }
 
 function getVueVersion(root: string): 2 | 2.7 | 3 {
-  const raw = getPackageInfoSync('vue', { paths: [root] })?.version || '3'
+  // To fixed [mlly] issue: https://github.com/unjs/mlly/issues/158
+  const fixedRoot = root.endsWith('/') ? root : `${root}/`
+  const raw = getPackageInfoSync('vue', { paths: [fixedRoot] })?.version || '3'
   const version = +(raw.split('.').slice(0, 2).join('.'))
   if (version === 2.7)
     return 2.7

--- a/src/core/options.ts
+++ b/src/core/options.ts
@@ -85,8 +85,7 @@ export function resolveOptions(options: Options, root: string): ResolvedOptions 
 
 function getVueVersion(root: string): 2 | 2.7 | 3 {
   // To fixed [mlly] issue: https://github.com/unjs/mlly/issues/158
-  const fixedRoot = root.endsWith('/') ? root : `${root}/`
-  const raw = getPackageInfoSync('vue', { paths: [fixedRoot] })?.version || '3'
+  const raw = getPackageInfoSync('vue', { paths: [join(root, '/')] })?.version || '3'
   const version = +(raw.split('.').slice(0, 2).join('.'))
   if (version === 2.7)
     return 2.7


### PR DESCRIPTION
### Description
If it's a directory, append a trailing slash at the end.https://github.com/unjs/mlly/issues/158#issuecomment-1468867050

### Linked Issues
fixed #767 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
