### PR TITLE
chor: bump version braces to 3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@rollup/pluginutils": "^5.1.0",
     "chokidar": "^3.6.0",
     "debug": "^4.3.4",
+    "braces": "^3.0.3",
     "fast-glob": "^3.3.2",
     "local-pkg": "^0.5.0",
     "magic-string": "^0.30.10",


### PR DESCRIPTION
https://github.com/advisories/GHSA-grv7-fg5c-xmjg braces有一个安全问题，发现是chokidar依赖了此包，我也在chokidar提交pull request，在chokidar发版之前应该把braces拿出来当显示依赖，达到升级到安全版本的目的
