### PR TITLE
feat: handle long extensions

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,7 +1,7 @@
 import type { FilterPattern } from '@rollup/pluginutils'
 import type { ComponentInfo, ImportInfo, ImportInfoLegacy, Options, ResolvedOptions } from '../types'
 import type { Context } from './context'
-import { parse } from 'node:path'
+import { basename, parse } from 'node:path'
 import process from 'node:process'
 import { slash, toArray } from '@antfu/utils'
 import {
@@ -114,7 +114,7 @@ export function stringifyComponentImport({ as: name, from: path, name: importNam
 }
 
 export function getNameFromFilePath(filePath: string, options: ResolvedOptions): string {
-  const { resolvedDirs, directoryAsNamespace, globalNamespaces, collapseSamePrefixes, root } = options
+  const { resolvedDirs, directoryAsNamespace, globalNamespaces, collapseSamePrefixes, root, resolvedExtensions } = options
 
   const parsedFilePath = parse(slash(filePath))
 
@@ -129,11 +129,14 @@ export function getNameFromFilePath(filePath: string, options: ResolvedOptions):
   }
 
   let folders = strippedPath.slice(1).split('/').filter(Boolean)
-  let filename = parsedFilePath.name
+  // when using `globs` option, `resolvedDirs` will always empty, and ignoring extensions is the expected behavior
+  let filename = isEmpty(resolvedDirs)
+    ? parsedFilePath.name
+    : basename(parsedFilePath.base, resolvedExtensions?.find(ext => parsedFilePath.base.endsWith(ext)))
 
   // set parent directory as filename if it is index
   if (filename === 'index' && !directoryAsNamespace) {
-    // when use `globs` option, `resolvedDirs` will always empty, and `folders` will also empty
+    // when using `globs` option, `resolvedDirs` will always empty, and `folders` will also empty
     if (isEmpty(folders))
       folders = parsedFilePath.dir.slice(root.length + 1).split('/').filter(Boolean)
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -189,6 +189,7 @@ export type ResolvedOptions = Omit<
 > & {
   resolvers: ComponentResolverObject[]
   extensions: string[]
+  resolvedExtensions: string[]
   dirs: string[]
   resolvedDirs: string[]
   globs: string[]

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,14 +1,16 @@
 import type { ResolvedOptions } from '../src'
 import { describe, expect, it } from 'vitest'
+import { resolveOptions } from '../src/core/options'
 import { getNameFromFilePath } from '../src/core/utils'
 
 describe('getNameFromFilePath', () => {
-  const options: Partial<ResolvedOptions> = {
+  const options: Partial<ResolvedOptions> = resolveOptions({
     directoryAsNamespace: true,
     globalNamespaces: [],
     collapseSamePrefixes: false,
-    resolvedDirs: ['/src/components'],
-  }
+    dirs: ['/src/components'],
+    extensions: ['vue', 'ce.vue'],
+  }, '/')
 
   it('normal name', () => {
     const inComponentFilePath = '/src/components/a/b.vue'
@@ -18,5 +20,15 @@ describe('getNameFromFilePath', () => {
   it('special char', () => {
     const inComponentFilePath = '/src/components/[a1]/b_2/c 3/d.4/[...ef]/ghi.vue'
     expect(getNameFromFilePath(inComponentFilePath, options as ResolvedOptions)).toBe('a1-b2-c3-d4-ef-ghi')
+  })
+
+  it(('long extensions'), () => {
+    const inComponentFilePath = '/src/components/b.ce.vue'
+    expect(getNameFromFilePath(inComponentFilePath, options as ResolvedOptions)).toBe('b')
+  })
+
+  it(('long extensions and nested'), () => {
+    const inComponentFilePath = '/src/components/a/b.ce.vue'
+    expect(getNameFromFilePath(inComponentFilePath, options as ResolvedOptions)).toBe('a-b')
   })
 })


### PR DESCRIPTION
Close #820

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Support obtaining component names correctly when extension options are in effect (while globs is ignoring) and long extensions are used.

### Linked Issues

#820

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

In order to handle dot numbers in extensions clearly and avoid BREAKING CHANGE, an internal option resolvedExtensions has been added