### PR TITLE
fix: compatible with vue-loader experimentalInlineMatchResource

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ export default {
 
       // `customLoaderMatcher` is depreacted, use `include` instead
 -     customLoaderMatcher: id => id.endsWith('.md'),
-+     include: [/\.vue$/, /\.vue(\.[tj]sx?)?\?vue/, /\.md$/],
++     include: [/\.vue$/, /\.vue\?vue/, /\.vue\.[tj]sx?\?vue/, /\.md$/],
     }),
   ],
 }
@@ -401,7 +401,7 @@ Components({
 
   // Filters for transforming targets (components to insert the auto import)
   // Note these are NOT about including/excluding components registered - use `globs` or `excludeNames` for that
-  include: [/\.vue$/, /\.vue(\.[tj]sx?)?\?vue/],
+  include: [/\.vue$/, /\.vue\?vue/, /\.vue\.[tj]sx?\?vue/],
   exclude: [/[\\/]node_modules[\\/]/, /[\\/]\.git[\\/]/, /[\\/]\.nuxt[\\/]/],
 
   // Filters for component names that will not be imported

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ export default {
 
       // `customLoaderMatcher` is depreacted, use `include` instead
 -     customLoaderMatcher: id => id.endsWith('.md'),
-+     include: [/\.vue$/, /\.vue(\.[t|j]sx?)?\?vue/, /\.md$/],
++     include: [/\.vue$/, /\.vue(\.[tj]sx?)?\?vue/, /\.md$/],
     }),
   ],
 }
@@ -401,7 +401,7 @@ Components({
 
   // Filters for transforming targets (components to insert the auto import)
   // Note these are NOT about including/excluding components registered - use `globs` or `excludeNames` for that
-  include: [/\.vue$/, /\.vue(\.[t|j]sx?)?\?vue/],
+  include: [/\.vue$/, /\.vue(\.[tj]sx?)?\?vue/],
   exclude: [/[\\/]node_modules[\\/]/, /[\\/]\.git[\\/]/, /[\\/]\.nuxt[\\/]/],
 
   // Filters for component names that will not be imported

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ export default {
 
       // `customLoaderMatcher` is depreacted, use `include` instead
 -     customLoaderMatcher: id => id.endsWith('.md'),
-+     include: [/\.vue$/, /\.vue\?vue/, /\.md$/],
++     include: [/\.vue$/, /\.vue(\.[t|j]sx?)?\?vue/, /\.md$/],
     }),
   ],
 }
@@ -401,7 +401,7 @@ Components({
 
   // Filters for transforming targets (components to insert the auto import)
   // Note these are NOT about including/excluding components registered - use `globs` or `excludeNames` for that
-  include: [/\.vue$/, /\.vue\?vue/],
+  include: [/\.vue$/, /\.vue(\.[t|j]sx?)?\?vue/],
   exclude: [/[\\/]node_modules[\\/]/, /[\\/]\.git[\\/]/, /[\\/]\.nuxt[\\/]/],
 
   // Filters for component names that will not be imported

--- a/src/core/unplugin.ts
+++ b/src/core/unplugin.ts
@@ -13,7 +13,7 @@ const PLUGIN_NAME = 'unplugin:webpack'
 
 export default createUnplugin<Options>((options = {}) => {
   const filter = createFilter(
-    options.include || [/\.vue$/, /\.vue\?vue/, /\.vue\?v=/],
+    options.include || [/\.vue$/, /\.vue(\.[t|j]sx?)?\?vue/, /\.vue\?v=/],
     options.exclude || [/[\\/]node_modules[\\/]/, /[\\/]\.git[\\/]/, /[\\/]\.nuxt[\\/]/],
   )
   const ctx: Context = new Context(options)

--- a/src/core/unplugin.ts
+++ b/src/core/unplugin.ts
@@ -13,7 +13,7 @@ const PLUGIN_NAME = 'unplugin:webpack'
 
 export default createUnplugin<Options>((options = {}) => {
   const filter = createFilter(
-    options.include || [/\.vue$/, /\.vue(\.[t|j]sx?)?\?vue/, /\.vue\?v=/],
+    options.include || [/\.vue$/, /\.vue(\.[tj]sx?)?\?vue/, /\.vue\?v=/],
     options.exclude || [/[\\/]node_modules[\\/]/, /[\\/]\.git[\\/]/, /[\\/]\.nuxt[\\/]/],
   )
   const ctx: Context = new Context(options)

--- a/src/core/unplugin.ts
+++ b/src/core/unplugin.ts
@@ -13,7 +13,12 @@ const PLUGIN_NAME = 'unplugin:webpack'
 
 export default createUnplugin<Options>((options = {}) => {
   const filter = createFilter(
-    options.include || [/\.vue$/, /\.vue(\.[tj]sx?)?\?vue/, /\.vue\?v=/],
+    options.include || [
+      /\.vue$/,
+      /\.vue\?vue/,
+      /\.vue\.[tj]sx?\?vue/, // for vue-loader with experimentalInlineMatchResource enabled
+      /\.vue\?v=/,
+    ],
     options.exclude || [/[\\/]node_modules[\\/]/, /[\\/]\.git[\\/]/, /[\\/]\.nuxt[\\/]/],
   )
   const ctx: Context = new Context(options)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description


When using vue-loader experimentalInlineMatchResource, the request will have an additional .js/.ts extension to match the js/ts module rule

```diff
// without experimentalInlineMatchResource
- src/App.vue?vue&type=script&setup=true&lang=ts
// with experimentalInlineMatchResource
+ src/App.vue.ts?vue&type=script&setup=true&lang=ts
```

But the default include RegExps failed to match the request


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
