### PR TITLE
feat: introduce `dumpComponentsInfo` option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules
 .DS_Store
 dist
 .idea
+.unimport-components.json
 components.d.ts

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ node_modules
 .DS_Store
 dist
 .idea
-.unimport-components.json
+.components-info.json
 components.d.ts

--- a/examples/vite-vue2/vite.config.ts
+++ b/examples/vite-vue2/vite.config.ts
@@ -8,6 +8,7 @@ const config: UserConfig = {
     Components({
       transformer: 'vue2',
       dts: 'src/components.d.ts',
+      dumpUnimportComponents: true,
     }),
   ],
   build: {

--- a/examples/vite-vue2/vite.config.ts
+++ b/examples/vite-vue2/vite.config.ts
@@ -8,7 +8,7 @@ const config: UserConfig = {
     Components({
       transformer: 'vue2',
       dts: 'src/components.d.ts',
-      dumpUnimportComponents: true,
+      dumpComponentsInfo: true,
     }),
   ],
   build: {

--- a/examples/vite-vue3/vite.config.ts
+++ b/examples/vite-vue3/vite.config.ts
@@ -37,7 +37,7 @@ const config: UserConfig = {
           componentPrefix: 'i',
         }),
       ],
-      dumpUnimportComponents: true,
+      dumpComponentsInfo: true,
     }),
   ],
   build: {

--- a/examples/vite-vue3/vite.config.ts
+++ b/examples/vite-vue3/vite.config.ts
@@ -37,6 +37,7 @@ const config: UserConfig = {
           componentPrefix: 'i',
         }),
       ],
+      dumpUnimportComponents: true,
     }),
   ],
   build: {

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -45,7 +45,7 @@ export class Context {
 
     if (this.options.dumpComponentsInfo) {
       const dumpComponentsInfo = this.options.dumpComponentsInfo === true
-        ? './.unimport-components.json'
+        ? './.components-info.json'
         : this.options.dumpComponentsInfo ?? false
 
       this.dumpComponentsInfoPath = dumpComponentsInfo
@@ -312,7 +312,7 @@ export class Context {
     if (!Object.keys(this._componentNameMap).length)
       return
 
-    debug.components('generating components.json')
+    debug.components('generating components-info')
     return writeComponentsJson(this, removeUnused)
   }
 

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -6,7 +6,7 @@ import process from 'node:process'
 import { slash, throttle, toArray } from '@antfu/utils'
 import Debug from 'debug'
 import { DIRECTIVE_IMPORT_PREFIX } from './constants'
-import { writeDeclaration } from './declaration'
+import { writeComponentsJson, writeDeclaration } from './declaration'
 import { searchComponents } from './fs/glob'
 import { resolveOptions } from './options'
 import transformer from './transformer'
@@ -34,6 +34,7 @@ export class Context {
   root = process.cwd()
   sourcemap: string | boolean = true
   alias: Record<string, string> = {}
+  dumpUnimportComponentsPath: string | undefined
 
   constructor(
     private rawOptions: Options,
@@ -41,6 +42,16 @@ export class Context {
     this.options = resolveOptions(rawOptions, this.root)
     this.sourcemap = rawOptions.sourcemap ?? true
     this.generateDeclaration = throttle(500, this._generateDeclaration.bind(this), { noLeading: false })
+
+    if (this.options.dumpUnimportComponents) {
+      const dumpUnimportComponents = this.options.dumpUnimportComponents === true
+        ? './.unimport-components.json'
+        : this.options.dumpUnimportComponents ?? false
+
+      this.dumpUnimportComponentsPath = dumpUnimportComponents
+      this.generateComponentsJson = throttle(500, this._generateComponentsJson.bind(this), { noLeading: false })
+    }
+
     this.setTransformer(this.options.transformer)
   }
 
@@ -288,12 +299,24 @@ export class Context {
     if (!this.options.dts)
       return
 
-    debug.declaration('generating')
+    debug.declaration('generating dts')
     return writeDeclaration(this, this.options.dts, removeUnused)
   }
 
   generateDeclaration(removeUnused = !this._server): void {
     this._generateDeclaration(removeUnused)
+  }
+
+  _generateComponentsJson(removeUnused = !this._server) {
+    if (!Object.keys(this._componentNameMap).length)
+      return
+
+    debug.components('generating components.json')
+    return writeComponentsJson(this, removeUnused)
+  }
+
+  generateComponentsJson(removeUnused = !this._server): void {
+    this._generateComponentsJson(removeUnused)
   }
 
   get componentNameMap() {

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -34,7 +34,7 @@ export class Context {
   root = process.cwd()
   sourcemap: string | boolean = true
   alias: Record<string, string> = {}
-  dumpUnimportComponentsPath: string | undefined
+  dumpComponentsInfoPath: string | undefined
 
   constructor(
     private rawOptions: Options,
@@ -43,12 +43,12 @@ export class Context {
     this.sourcemap = rawOptions.sourcemap ?? true
     this.generateDeclaration = throttle(500, this._generateDeclaration.bind(this), { noLeading: false })
 
-    if (this.options.dumpUnimportComponents) {
-      const dumpUnimportComponents = this.options.dumpUnimportComponents === true
+    if (this.options.dumpComponentsInfo) {
+      const dumpComponentsInfo = this.options.dumpComponentsInfo === true
         ? './.unimport-components.json'
-        : this.options.dumpUnimportComponents ?? false
+        : this.options.dumpComponentsInfo ?? false
 
-      this.dumpUnimportComponentsPath = dumpUnimportComponents
+      this.dumpComponentsInfoPath = dumpComponentsInfo
       this.generateComponentsJson = throttle(500, this._generateComponentsJson.bind(this), { noLeading: false })
     }
 

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -180,6 +180,7 @@ export class Context {
 
   onUpdate(path: string) {
     this.generateDeclaration()
+    this.generateComponentsJson()
 
     if (!this._server)
       return

--- a/src/core/declaration.ts
+++ b/src/core/declaration.ts
@@ -158,7 +158,7 @@ export async function writeDeclaration(ctx: Context, filepath: string, removeUnu
 }
 
 export async function writeComponentsJson(ctx: Context, _removeUnused = false) {
-  if (!ctx.dumpUnimportComponentsPath)
+  if (!ctx.dumpComponentsInfoPath)
     return
 
   const components = [
@@ -173,5 +173,5 @@ export async function writeComponentsJson(ctx: Context, _removeUnused = false) {
     ...resolveTypeImports(ctx.options.types),
   ]
 
-  await writeFile(ctx.dumpUnimportComponentsPath, JSON.stringify(components, null, 2))
+  await writeFile(ctx.dumpComponentsInfoPath, JSON.stringify(components, null, 2))
 }

--- a/src/core/declaration.ts
+++ b/src/core/declaration.ts
@@ -156,3 +156,22 @@ export async function writeDeclaration(ctx: Context, filepath: string, removeUnu
   if (code !== originalContent)
     await writeFile(filepath, code)
 }
+
+export async function writeComponentsJson(ctx: Context, _removeUnused = false) {
+  if (!ctx.dumpUnimportComponentsPath)
+    return
+
+  const components = [
+    ...Object.entries({
+      ...ctx.componentNameMap,
+      ...ctx.componentCustomMap,
+    }).map(([_, { name, as, from }]) => ({
+      name: name || 'default',
+      as,
+      from,
+    })),
+    ...resolveTypeImports(ctx.options.types),
+  ]
+
+  await writeFile(ctx.dumpUnimportComponentsPath, JSON.stringify(components, null, 2))
+}

--- a/src/core/unplugin.ts
+++ b/src/core/unplugin.ts
@@ -70,8 +70,8 @@ export default createUnplugin<Options>((options = {}) => {
             ctx.generateDeclaration()
         }
 
-        if (ctx.options.dumpUnimportComponents && ctx.dumpUnimportComponentsPath) {
-          if (!existsSync(ctx.dumpUnimportComponentsPath))
+        if (ctx.options.dumpComponentsInfo && ctx.dumpComponentsInfoPath) {
+          if (!existsSync(ctx.dumpComponentsInfoPath))
             ctx.generateComponentsJson()
         }
 

--- a/src/core/unplugin.ts
+++ b/src/core/unplugin.ts
@@ -48,6 +48,7 @@ export default createUnplugin<Options>((options = {}) => {
       try {
         const result = await ctx.transform(code, id)
         ctx.generateDeclaration()
+        ctx.generateComponentsJson()
         return result
       }
       catch (e) {
@@ -67,6 +68,11 @@ export default createUnplugin<Options>((options = {}) => {
           ctx.searchGlob()
           if (!existsSync(ctx.options.dts))
             ctx.generateDeclaration()
+        }
+
+        if (ctx.options.dumpUnimportComponents && ctx.dumpUnimportComponentsPath) {
+          if (!existsSync(ctx.dumpUnimportComponentsPath))
+            ctx.generateComponentsJson()
         }
 
         if (config.build.watch && config.command === 'build')

--- a/src/types.ts
+++ b/src/types.ts
@@ -210,7 +210,7 @@ export interface Options {
    * Save unimport components into a JSON file for other tools to consume.
    * Provide a filepath to save the JSON file.
    *
-   * When set to `true`, it will save to `./.unimport-components.json`
+   * When set to `true`, it will save to `./.components-info.json`
    *
    * @default false
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -207,7 +207,7 @@ export interface Options {
   sourcemap?: boolean
 
   /**
-   * Save unimport components into a JSON file for other tools to consume.
+   * Save component information into a JSON file for other tools to consume.
    * Provide a filepath to save the JSON file.
    *
    * When set to `true`, it will save to `./.components-info.json`

--- a/src/types.ts
+++ b/src/types.ts
@@ -205,6 +205,16 @@ export interface Options {
    * @default true
    */
   sourcemap?: boolean
+
+  /**
+   * Save unimport components into a JSON file for other tools to consume.
+   * Provide a filepath to save the JSON file.
+   *
+   * When set to `true`, it will save to `./.unimport-components.json`
+   *
+   * @default false
+   */
+  dumpUnimportComponents?: boolean | string
 }
 
 export type ResolvedOptions = Omit<

--- a/src/types.ts
+++ b/src/types.ts
@@ -214,7 +214,7 @@ export interface Options {
    *
    * @default false
    */
-  dumpUnimportComponents?: boolean | string
+  dumpComponentsInfo?: boolean | string
 }
 
 export type ResolvedOptions = Omit<


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR will add a `dumpUnimportComponents` option to export information about all components.

I recently created an [eslint-plugin-unimport-components](https://github.com/ilyaliao/eslint-plugin-unimport-components) tool to automatically complete imports, inspired by [eslint-plugin-unimport](https://github.com/antfu/eslint-plugin-unimport). I hope to collaborate with `unplugin-vue-components` to obtain information about all components, allowing ESLint to automatically import components.


(Automatically Generated Components JSON File)
<img width="929" alt="截圖 2025-02-25 凌晨2 01 29" src="https://github.com/user-attachments/assets/12e7d7e6-9c19-4c68-9e67-20ac733d444f" />

(Eslint Error Message)
<img width="1107" alt="截圖 2025-02-25 凌晨2 04 46" src="https://github.com/user-attachments/assets/a1475ff9-7b76-490c-abac-b627d3567cbd" />
