### PR TITLE
feat: use `GlobalDirectives` instead of `ComponentCustomProperties`

### DIFF
--- a/src/core/declaration.ts
+++ b/src/core/declaration.ts
@@ -31,7 +31,7 @@ export function parseDeclaration(code: string): DeclarationImports | undefined {
   if (componentDeclaration)
     imports.component = extractImports(componentDeclaration)
 
-  const directiveDeclaration = /export\s+interface\s+ComponentCustomProperties\s*\{.*?\}/s.exec(code)?.[0]
+  const directiveDeclaration = /export\s+interface\s+GlobalDirectives\s*\{.*?\}/s.exec(code)?.[0]
   if (directiveDeclaration)
     imports.directive = extractImports(directiveDeclaration)
 
@@ -133,9 +133,6 @@ declare module 'vue' {`
   if (Object.keys(declarations.directive).length > 0) {
     code += `
   export interface GlobalDirectives {
-    ${declarations.directive.join('\n    ')}
-  }
-  export interface ComponentCustomProperties {
     ${declarations.directive.join('\n    ')}
   }`
   }

--- a/src/core/declaration.ts
+++ b/src/core/declaration.ts
@@ -132,6 +132,9 @@ declare module 'vue' {`
   }
   if (Object.keys(declarations.directive).length > 0) {
     code += `
+  export interface GlobalDirectives {
+    ${declarations.directive.join('\n    ')}
+  }
   export interface ComponentCustomProperties {
     ${declarations.directive.join('\n    ')}
   }`

--- a/test/__snapshots__/dts.test.ts.snap
+++ b/test/__snapshots__/dts.test.ts.snap
@@ -29,6 +29,9 @@ export {}
 
 /* prettier-ignore */
 declare module 'vue' {
+  export interface GlobalDirectives {
+    vLoading: typeof import('test/directive/Loading')['default']
+  }
   export interface ComponentCustomProperties {
     vLoading: typeof import('test/directive/Loading')['default']
   }
@@ -50,6 +53,9 @@ declare module 'vue' {
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     TestComp: typeof import('test/component/TestComp')['default']
+  }
+  export interface GlobalDirectives {
+    vLoading: typeof import('test/directive/Loading')['default']
   }
   export interface ComponentCustomProperties {
     vLoading: typeof import('test/directive/Loading')['default']
@@ -130,6 +136,11 @@ declare module 'vue' {
     SomeComp: typeof import('test/component/SomeComp')['default']
     TestComp: typeof import('test/component/TestComp')['default']
   }
+  export interface GlobalDirectives {
+    vDirective: typeof import('foo')
+    vLoading: typeof import('test/directive/Loading')['default']
+    vSome: typeof import('test/directive/Some')['default']
+  }
   export interface ComponentCustomProperties {
     vDirective: typeof import('foo')
     vLoading: typeof import('test/directive/Loading')['default']
@@ -153,6 +164,9 @@ declare module 'vue' {
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     TestComp: typeof import('test/component/TestComp')['default']
+  }
+  export interface GlobalDirectives {
+    vLoading: typeof import('test/directive/Loading')['default']
   }
   export interface ComponentCustomProperties {
     vLoading: typeof import('test/directive/Loading')['default']

--- a/test/__snapshots__/dts.test.ts.snap
+++ b/test/__snapshots__/dts.test.ts.snap
@@ -32,9 +32,6 @@ declare module 'vue' {
   export interface GlobalDirectives {
     vLoading: typeof import('test/directive/Loading')['default']
   }
-  export interface ComponentCustomProperties {
-    vLoading: typeof import('test/directive/Loading')['default']
-  }
 }
 "
 `;
@@ -55,9 +52,6 @@ declare module 'vue' {
     TestComp: typeof import('test/component/TestComp')['default']
   }
   export interface GlobalDirectives {
-    vLoading: typeof import('test/directive/Loading')['default']
-  }
-  export interface ComponentCustomProperties {
     vLoading: typeof import('test/directive/Loading')['default']
   }
 }
@@ -141,11 +135,6 @@ declare module 'vue' {
     vLoading: typeof import('test/directive/Loading')['default']
     vSome: typeof import('test/directive/Some')['default']
   }
-  export interface ComponentCustomProperties {
-    vDirective: typeof import('foo')
-    vLoading: typeof import('test/directive/Loading')['default']
-    vSome: typeof import('test/directive/Some')['default']
-  }
 }
 "
 `;
@@ -166,9 +155,6 @@ declare module 'vue' {
     TestComp: typeof import('test/component/TestComp')['default']
   }
   export interface GlobalDirectives {
-    vLoading: typeof import('test/directive/Loading')['default']
-  }
-  export interface ComponentCustomProperties {
     vLoading: typeof import('test/directive/Loading')['default']
   }
 }

--- a/test/dts.test.ts
+++ b/test/dts.test.ts
@@ -57,7 +57,7 @@ declare module 'vue' {
     SomeComp: typeof import('test/component/SomeComp')['default']
     TestComp: typeof import('test/component/OldComp')['default']
   }
-  export   interface   ComponentCustomProperties{
+  export   interface   GlobalDirectives{
     // with comment: b
     // a:
     vSome: typeof import('test/directive/Some')['default'];vDirective:typeof import('foo')
@@ -179,7 +179,7 @@ declare module 'vue' {
     IMdiLightAlarm: typeof import('~icons/mdi-light/alarm')['default']
   }
 
-  export interface ComponentCustomProperties {
+  export interface GlobalDirectives {
     vDirective: typeof import('foo')
     vLoading: typeof import('test/directive/Loading')['default']
     vSome: typeof import('test/directive/Some')['default']


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Vue Language Tools uses `GlobalDirectives` to provide type support for global directives. `ComponentCustomProperties` causes directives incorrectly appear in the component's properties.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
