### PR TITLE
fix: correct prefixed component name

### DIFF
--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -215,7 +215,10 @@ export class Context {
     Array
       .from(this._componentPaths)
       .forEach((path) => {
-        const name = pascalCase(getNameFromFilePath(path, this.options))
+        const fileName = getNameFromFilePath(path, this.options)
+        const name = this.options.prefix
+          ? `${pascalCase(this.options.prefix)}${pascalCase(fileName)}`
+          : pascalCase(fileName)
         if (isExclude(name, this.options.excludeNames)) {
           debug.components('exclude', name)
           return

--- a/src/core/declaration.ts
+++ b/src/core/declaration.ts
@@ -38,16 +38,6 @@ export function parseDeclaration(code: string): DeclarationImports | undefined {
   return imports
 }
 
-function addComponentPrefix(component: ComponentInfo, prefix?: string) {
-  if (!component.as || !prefix)
-    return component
-
-  return {
-    ...component,
-    as: `${prefix}${component.as}`,
-  }
-}
-
 /**
  * Converts `ComponentInfo` to an array
  *
@@ -82,10 +72,11 @@ export interface DeclarationImports {
 }
 
 export function getDeclarationImports(ctx: Context, filepath: string): DeclarationImports | undefined {
-  const prefixComponentNameMap = Object.values(ctx.componentNameMap).map(info => addComponentPrefix(info, ctx.options.prefix))
   const component = stringifyComponentsInfo(filepath, [
-    ...Object.values(ctx.componentCustomMap),
-    ...prefixComponentNameMap,
+    ...Object.values({
+      ...ctx.componentNameMap,
+      ...ctx.componentCustomMap,
+    }),
     ...resolveTypeImports(ctx.options.types),
   ], ctx.options.importPathTransform)
 

--- a/test/__snapshots__/transform.test.ts.snap
+++ b/test/__snapshots__/transform.test.ts.snap
@@ -63,6 +63,28 @@ import __unplugin_components_0 from 'test/component/ElInfiniteScroll';
 }
 `;
 
+exports[`prefix transform > transform with prefix should work 1`] = `
+{
+  "code": "/* unplugin-vue-components disabled */import __unplugin_components_2 from 'test/component/test-comp.vue';
+import __unplugin_components_1 from 'test/component/test-comp.vue';
+import __unplugin_components_0 from 'test/component/test-comp.vue';
+
+    const render = (_ctx, _cache) => {
+      const _component_test_comp = __unplugin_components_0
+      const _component_testComp = __unplugin_components_1
+      const _component_testComp = __unplugin_components_2
+
+      return _withDirectives(
+        (_openBlock(),
+        _createBlock(_component_test_comp, null, null, 512 /* NEED_PATCH */)),
+        _createBlock(_component_testComp, null, null, 512 /* NEED_PATCH */)),
+        _createBlock(_component_TestComp, null, null, 512 /* NEED_PATCH */))
+      )
+    }
+    ",
+}
+`;
+
 exports[`transform > vue2 transform should work 1`] = `
 {
   "code": "/* unplugin-vue-components disabled */import __unplugin_directives_0 from 'test/directive/Loading';


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
The `prefix` option from #850 was only applied to type declarations, which caused a resolution failure during the transform stage. 

This PR corrects the behavior by applying the prefix to the internal `componentNameMap` and adds tests to prevent regressions.