### PR TITLE
fix(tdesign): add QRCode component support

### DIFF
--- a/src/core/resolvers/tdesign.ts
+++ b/src/core/resolvers/tdesign.ts
@@ -53,7 +53,7 @@ export function TDesignResolver(options: TDesignResolverOptions = {}): Component
         }
       }
 
-      if (name.startsWith('TQrcode') || name.startsWith('Qrcode')) {
+      if (name.startsWith('TQrcode')) {
         return {
           name: 'QRCode',
           from: `tdesign-${library}${importFrom}`,

--- a/src/core/resolvers/tdesign.ts
+++ b/src/core/resolvers/tdesign.ts
@@ -53,6 +53,13 @@ export function TDesignResolver(options: TDesignResolverOptions = {}): Component
         }
       }
 
+      if (name.startsWith('TQrcode') || name.startsWith('Qrcode')) {
+        return {
+          name: 'QRCode',
+          from: `tdesign-${library}${importFrom}`,
+        }
+      }
+
       if (name.match(/^T[A-Z]/) || pluginList.includes(name)) {
         const importName = name.match(/^T[A-Z]/) ? name.slice(1) : name
 


### PR DESCRIPTION


### Description

Fix TDesign "QRCode" component cannot be imported due to case sensitivity.
Modify the export to be "QRCode" instead of "Qrcode".

<img width="2908" height="828" alt="image" src="https://github.com/user-attachments/assets/68f70127-be0d-4fef-b0ae-fc9a6cb2499b" />


### Additional context

Code reference: https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/auto-import-resolver/src/resolver.ts
