### PR TITLE
perf: hoist slash() call out of matchGlobs loop

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -58,9 +58,10 @@ export function isEmpty(value: any) {
 }
 
 export function matchGlobs(filepath: string, globs: string[]) {
+  const file = slash(filepath)
   for (const glob of globs) {
     const isNegated = glob[0] === '!'
-    const match = picomatch(isNegated ? glob.slice(1) : glob)(slash(filepath))
+    const match = picomatch(isNegated ? glob.slice(1) : glob)(file)
     if (match)
       return !isNegated
   }


### PR DESCRIPTION
### Description

This PR hoists `slash(filepath)` out of the `matchGlobs` loop so it's computed once per call instead of once per glob, since the value is invariant across iterations.