### PR TITLE
fix: escape square brackets in glob paths

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -243,8 +243,8 @@ export function isExclude(name: string, exclude?: FilterPattern): boolean {
   return false
 }
 
-const ESCAPE_PARENTHESES_REGEX = /[()]/g
+const ESCAPE_SPECIAL_CHARS_REGEX = /[()[\]]/g
 
 export function escapeSpecialChars(str: string): string {
-  return str.replace(ESCAPE_PARENTHESES_REGEX, '\\$&')
+  return str.replace(ESCAPE_SPECIAL_CHARS_REGEX, '\\$&')
 }


### PR DESCRIPTION
## Problem

When the file path contains square brackets (e.g. FiveM resource groups like `[GoodCategoryName]`), the `matchGlobs` function fails because `picomatch` interprets `[Resource]` as a character class.

## Root Cause

The `escapeSpecialChars` function in `src/core/utils.ts` only escapes parentheses `()` but not square brackets `[]`.

## Fix

Added square brackets to the escape regex:

```diff
- const ESCAPE_PARENTHESES_REGEX = /[()]/g
+ const ESCAPE_SPECIAL_CHARS_REGEX = /[()[\]]/g
```

This ensures paths like `C:/Github/Project/[Resource]/ui/src/component/**/*.vue` are properly escaped before matching.

Fixes #810