### PR TITLE
[codex] Fix root types entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "./webpack": "./dist/webpack.mjs",
     "./package.json": "./package.json"
   },
-  "types": "./dist/index.d.ts",
+  "types": "./dist/index.d.mts",
   "typesVersions": {
     "*": {
       "*": [


### PR DESCRIPTION
## Summary

This fixes the root TypeScript declaration entry in `package.json`.

The published package/build output emits `dist/index.d.mts`, but the root `types` field currently points to `./dist/index.d.ts`, which is not present in the package tarball. TypeScript consumers that read the root `types` field can therefore resolve a missing declaration file.

## Change

- Update `types` from `./dist/index.d.ts` to `./dist/index.d.mts`.

## Validation

- `npm pack unplugin-vue-components@32.1.0 --dry-run --json` confirmed the published tarball contains `dist/index.d.mts` and not `dist/index.d.ts`.
- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm build`
- `node -e "const fs=require('fs'); const p=require('./package.json'); console.log(JSON.stringify({types:p.types, typesExists:fs.existsSync(p.types)}, null, 2))"`
- `npm pack --dry-run --json`
- `corepack pnpm test --run` (9 files / 36 tests passed)
- `git diff --check`