### PR TITLE
fix: escape pipes in glob paths

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -243,8 +243,8 @@ export function isExclude(name: string, exclude?: FilterPattern): boolean {
   return false
 }
 
-const ESCAPE_PARENTHESES_REGEX = /[()]/g
+const ESCAPE_SPECIAL_CHARS_REGEX = /[()|]/g
 
 export function escapeSpecialChars(str: string): string {
-  return str.replace(ESCAPE_PARENTHESES_REGEX, '\\$&')
+  return str.replace(ESCAPE_SPECIAL_CHARS_REGEX, '\\$&')
 }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,6 +1,6 @@
 import type { ResolvedOptions } from '../src'
 import { describe, expect, it } from 'vitest'
-import { escapeSpecialChars, getNameFromFilePath } from '../src/core/utils'
+import { escapeSpecialChars, getNameFromFilePath, matchGlobs } from '../src/core/utils'
 
 describe('getNameFromFilePath', () => {
   const options: Partial<ResolvedOptions> = {
@@ -24,5 +24,11 @@ describe('getNameFromFilePath', () => {
 describe('escapeSpecialChars', () => {
   it('should escape parentheses', () => {
     expect(escapeSpecialChars('component()')).toBe('component\\(\\)')
+  })
+
+  it('should escape pipes in glob paths', () => {
+    const glob = escapeSpecialChars('/work/|presentation/components/**/*.vue')
+
+    expect(matchGlobs('/work/|presentation/components/Foo.vue', [glob])).toBe(true)
   })
 })


### PR DESCRIPTION
### Description

Paths containing `|` are treated as alternation by picomatch, so directory-based component discovery misses files under paths such as `/work/|presentation`.

This escapes pipes when generating globs and adds a regression test for the matcher.

Follow-up to slidevjs/slidev#2668.

### Tests

- `pnpm test --run`
- `pnpm typecheck`
- `pnpm build`
- `pnpm exec eslint src/core/utils.ts test/utils.test.ts`